### PR TITLE
Widow_fixes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -102,7 +102,9 @@
 #define COMSIG_ELEMENT_CLOSE_SHUTTER_LINKED "close_shutter_linked"
 ///from turf/open/get_footstep_override(), to find an override footstep sound
 #define COMSIG_FIND_FOOTSTEP_SOUND "find_footstep_sound"
-///from /datum/element/jump when a jump has finished
+
+///from /datum/element/jump when a jump has started and ended
+#define COMSIG_ELEMENT_JUMP_STARTED "element_jump_started"
 #define COMSIG_ELEMENT_JUMP_ENDED "element_jump_ended"
 
 // /datum/limb signals

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -102,7 +102,7 @@
 #define OPTABLE_TRAIT "optable"
 #define TIMESHIFT_TRAIT "timeshift"
 #define BRAIN_TRAIT "brain"
-#define WIDOW_ABILITY_TRAIT "widow_ability_trait"
+#define WIDOW_RIDING_TRAIT "widow_riding_trait"
 #define PSYCHIC_BLAST_ABILITY_TRAIT "psychic_blast_ability_trait"
 #define PSYCHIC_CRUSH_ABILITY_TRAIT "psychic_crush_ability_trait"
 #define VORTEX_ABILITY_TRAIT "vortex_ability_trait"

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -64,6 +64,7 @@
 
 	jumper.layer = ABOVE_MOB_LAYER
 
+	SEND_SIGNAL(jumper, COMSIG_ELEMENT_JUMP_STARTED)
 	jumper.adjustStaminaLoss(stamina_cost)
 	jumper.pass_flags |= jumper_allow_pass_flags
 	ADD_TRAIT(jumper, TRAIT_SILENT_FOOTSTEPS, JUMP_COMPONENT)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -304,7 +304,7 @@
 /datum/component/riding/creature/widow/vehicle_mob_unbuckle(datum/source, mob/living/former_rider, force = FALSE)
 	unequip_buckle_inhands(parent)
 	former_rider.density = initial(former_rider.density)
-	REMOVE_TRAIT(former_rider, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
+	REMOVE_TRAIT(former_rider, TRAIT_IMMOBILE, WIDOW_RIDING_TRAIT)
 	return ..()
 
 /// If the widow gets knocked over, force the riding rounys off and see if someone got hurt
@@ -312,4 +312,4 @@
 	SIGNAL_HANDLER
 	for(var/mob/living/rider AS in carrying_widow.buckled_mobs)
 		carrying_widow.unbuckle_mob(rider)
-		REMOVE_TRAIT(rider, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
+		REMOVE_TRAIT(rider, TRAIT_IMMOBILE, WIDOW_RIDING_TRAIT)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -299,7 +299,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, PROC_REF(vehicle_turned))
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, PROC_REF(vehicle_mob_unbuckle))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(vehicle_moved))
-	RegisterSignal(parent, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(check_widow_attack))
+	RegisterSignals(parent, list(COMSIG_XENOMORPH_ATTACK_LIVING, COMSIG_XENOMORPH_ATTACK_OBJ), PROC_REF(check_widow_attack))
 
 /datum/component/riding/creature/widow/vehicle_mob_unbuckle(datum/source, mob/living/former_rider, force = FALSE)
 	unequip_buckle_inhands(parent)

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -318,6 +318,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		if(isxeno(M))
 			var/mob/living/carbon/xenomorph/X = M
 			X.transfer_to_hive(pick(XENO_HIVE_NORMAL, XENO_HIVE_CORRUPTED, XENO_HIVE_ALPHA, XENO_HIVE_BETA, XENO_HIVE_ZETA))
+			X.on_eord(picked)
 			INVOKE_ASYNC(X, TYPE_PROC_REF(/atom/movable, forceMove), picked)
 
 		else if(ishuman(M))

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -367,7 +367,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 	else
 		step_dir = get_dir(mob_parent, atom_to_walk_to)
 	var/turf/next_turf = get_step(mob_parent, step_dir)
-	if(next_turf.flags_atom & AI_BLOCKED || (!mob_parent.Move(next_turf, step_dir) && !(SEND_SIGNAL(mob_parent, COMSIG_OBSTRUCTED_MOVE, step_dir) & COMSIG_OBSTACLE_DEALT_WITH)))
+	if(next_turf?.flags_atom & AI_BLOCKED || (!mob_parent.Move(next_turf, step_dir) && !(SEND_SIGNAL(mob_parent, COMSIG_OBSTRUCTED_MOVE, step_dir) & COMSIG_OBSTACLE_DEALT_WITH)))
 		step_dir = pick(LeftAndRightOfDir(step_dir))
 		next_turf = get_step(mob_parent, step_dir)
 		if(next_turf.flags_atom & AI_BLOCKED)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -194,6 +194,8 @@
 	if (X.fortify)
 		return FALSE
 
+	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_LIVING, src, damage_amount, X.xeno_caste.melee_damage * X.xeno_melee_damage_modifier)
+
 	switch(X.a_intent)
 		if(INTENT_HELP)
 			if(on_fire)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -106,7 +106,7 @@
 			change_action(ESCORTING_ATOM, escorted_atom)
 			return
 	mob_parent.face_atom(atom_to_walk_to)
-	addtimer(CALLBACK(mob_parent, TYPE_PROC_REF(/mob, UnarmedAttack), atom_to_walk_to, mob_parent), rand(1, 10) MILLISECONDS)
+	addtimer(CALLBACK(mob_parent, TYPE_PROC_REF(/mob, UnarmedAttack), atom_to_walk_to, mob_parent), rand(1, 15) MILLISECONDS)
 
 /// Check if escorted_atom moves away from the spiderling while it's attacking something, this is to always keep them close to escorted_atom
 /datum/ai_behavior/spiderling/look_for_new_state()

--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/spiderling.dm
@@ -19,6 +19,7 @@
 /mob/living/carbon/xenomorph/spiderling/Initialize(mapload, mob/living/carbon/xenomorph/spidermother)
 	. = ..()
 	AddComponent(/datum/component/ai_controller, /datum/ai_behavior/spiderling, spidermother)
+	transfer_to_hive(spidermother.get_xeno_hivenumber())
 
 /mob/living/carbon/xenomorph/spiderling/on_death()
 	///We QDEL them as cleanup and preventing them from being sold
@@ -42,7 +43,9 @@
 	RegisterSignal(escorted_atom, COMSIG_MOB_DEATH, PROC_REF(spiderling_rage))
 	RegisterSignal(escorted_atom, COMSIG_LIVING_DO_RESIST, PROC_REF(parent_resist))
 	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_RESIN_JELLY_APPLIED, PROC_REF(apply_spiderling_jelly))
-	RegisterSignals(escorted_atom, list(COMSIG_XENOMORPH_REST, COMSIG_XENOMORPH_UNREST), PROC_REF(toggle_rest))
+	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_REST, PROC_REF(start_resting))
+	RegisterSignal(escorted_atom, COMSIG_XENOMORPH_UNREST, PROC_REF(stop_resting))
+	RegisterSignal(escorted_atom, COMSIG_ELEMENT_JUMP_STARTED, PROC_REF(do_jump))
 	RegisterSignal(escorted_atom, COMSIG_SPIDERLING_MARK, PROC_REF(decide_mark))
 
 /// Decides what to do when widow uses spiderling mark ability
@@ -103,7 +106,7 @@
 			change_action(ESCORTING_ATOM, escorted_atom)
 			return
 	mob_parent.face_atom(atom_to_walk_to)
-	mob_parent.UnarmedAttack(atom_to_walk_to, mob_parent)
+	addtimer(CALLBACK(mob_parent, TYPE_PROC_REF(/mob, UnarmedAttack), atom_to_walk_to, mob_parent), rand(1, 10) MILLISECONDS)
 
 /// Check if escorted_atom moves away from the spiderling while it's attacking something, this is to always keep them close to escorted_atom
 /datum/ai_behavior/spiderling/look_for_new_state()
@@ -128,16 +131,18 @@
 
 /// This happens when the spiderlings mother dies, they move faster and will attack any nearby marines
 /datum/ai_behavior/spiderling/proc/spiderling_rage()
+	SIGNAL_HANDLER
 	var/mob/living/carbon/xenomorph/spiderling/x = mob_parent
 	var/list/mob/living/carbon/human/possible_victims = list()
-	for(var/mob/living/carbon/human/victim in cheap_get_humans_near(x, SPIDERLING_RAGE_RANGE))
+	for(var/mob/living/victim in get_nearest_target(x, SPIDERLING_RAGE_RANGE))
 		if(victim.stat == DEAD)
 			continue
 		possible_victims += victim
 	if(!length(possible_victims))
 		kill_parent()
 		return
-	x.emote("roar")
+	// Makes the spiderlings roar at slightly different times so they don't stack their roars
+	addtimer(CALLBACK(x, TYPE_PROC_REF(/mob, emote), "roar"), rand(50, 200)  MILLISECONDS)
 	change_action(MOVING_TO_ATOM, pick(possible_victims))
 	addtimer(CALLBACK(src, PROC_REF(kill_parent)), 10 SECONDS)
 
@@ -145,7 +150,7 @@
 /datum/ai_behavior/spiderling/proc/triggered_spiderling_rage(mob/M, mob/victim)
 	var/mob/living/carbon/xenomorph/spiderling/x = mob_parent
 	change_action(MOVING_TO_ATOM, victim)
-	x.emote("roar")
+	addtimer(CALLBACK(x, TYPE_PROC_REF(/mob, emote), "roar"), rand(50, 200) MILLISECONDS)
 	addtimer(CALLBACK(src, PROC_REF(kill_parent)), 15 SECONDS)
 
 ///This kills the spiderling
@@ -155,16 +160,25 @@
 
 /// resist when widow does
 /datum/ai_behavior/spiderling/proc/parent_resist()
+	SIGNAL_HANDLER
 	var/mob/living/carbon/xenomorph/spiderling/spiderling_parent = mob_parent
 	spiderling_parent.do_resist()
 
 /// rest and unrest when widow does
-/datum/ai_behavior/spiderling/proc/toggle_rest()
-	var/mob/living/carbon/xenomorph/spiderling/spiderling_parent = mob_parent
-	if(HAS_TRAIT(spiderling_parent, TRAIT_FLOORED))
-		spiderling_parent.set_resting(FALSE)
-	else
-		spiderling_parent.set_resting(TRUE)
+/datum/ai_behavior/spiderling/proc/start_resting(mob/source)
+	SIGNAL_HANDLER
+	var/mob/living/living = mob_parent
+	living.set_resting(TRUE)
+
+/datum/ai_behavior/spiderling/proc/stop_resting(mob/source)
+	SIGNAL_HANDLER
+	var/mob/living/living = mob_parent
+	living.set_resting(FALSE)
+	source.unbuckle_all_mobs()
+
+/datum/ai_behavior/spiderling/proc/do_jump()
+	SIGNAL_HANDLER
+	SEND_SIGNAL(mob_parent, COMSIG_KB_LIVING_JUMP)
 
 /// Signal handler to apply resin jelly to the spiderling whenever widow gets it
 /datum/ai_behavior/spiderling/proc/apply_spiderling_jelly()

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -129,7 +129,7 @@
 /datum/action/xeno_action/create_spiderling
 	name = "Birth Spiderling"
 	ability_name = "birth_spiderling"
-	desc = "Give birth to a spiderling after a short charge-up. The spiderlings will follow you until death. You can only deploy 5 spiderlings at one time. On alt-use, if any charges of Cannibalise are stored, create a spiderling at no plasma cost or cooldown."
+	desc = "Give birth to a spiderling after a short charge-up. The spiderlings will follow you until death. You can only deploy 4 spiderlings at one time. On alt-use, if any charges of Cannibalise are stored, create a spiderling at no plasma cost or cooldown."
 	action_icon_state = "spawn_spiderling"
 	plasma_cost = 100
 	cooldown_timer = 15 SECONDS
@@ -140,6 +140,12 @@
 	var/list/mob/living/carbon/xenomorph/spiderling/spiderlings = list()
 	/// Current amount of cannibalise charges
 	var/cannibalise_charges = 0
+
+/datum/action/xeno_action/create_spiderling/New(Target)
+	. = ..()
+	var/mob/living/carbon/xenomorph/X = owner
+	var/max_spiderlings = X?.xeno_caste.max_spiderlings ? X.xeno_caste.max_spiderlings : 4
+	desc = "Give birth to a spiderling after a short charge-up. The spiderlings will follow you until death. You can only deploy [max_spiderlings] spiderlings at one time. On alt-use, if any charges of Cannibalise are stored, create a spiderling at no plasma cost or cooldown."
 
 /datum/action/xeno_action/create_spiderling/can_use_action(silent = FALSE, override_flags)
 	. = ..()
@@ -269,11 +275,14 @@
 	X.mouse_opacity = initial(X.mouse_opacity)
 	X.density = TRUE
 	X.allow_pass_flags &= ~PASSABLE
-	REMOVE_TRAIT(X, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
-	REMOVE_TRAIT(X, TRAIT_BURROWED, WIDOW_ABILITY_TRAIT)
-	REMOVE_TRAIT(X, TRAIT_HANDS_BLOCKED, WIDOW_ABILITY_TRAIT)
+	REMOVE_TRAIT(X, TRAIT_IMMOBILE, ability_name)
+	REMOVE_TRAIT(X, TRAIT_BURROWED, ability_name)
+	REMOVE_TRAIT(X, TRAIT_HANDS_BLOCKED, ability_name)
 	X.update_icons()
 	add_cooldown()
+	if(!owner.buckled_mobs)
+		return
+	owner.unbuckle_all_mobs(TRUE)
 
 /// Called by xeno_burrow only when burrowing
 /datum/action/xeno_action/burrow/proc/xeno_burrow_doafter()
@@ -285,9 +294,9 @@
 	owner.density = FALSE
 	owner.allow_pass_flags |= PASSABLE
 	// Here we prevent the xeno from moving or attacking or using abilities untill they unburrow by clicking the ability
-	ADD_TRAIT(owner, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
-	ADD_TRAIT(owner, TRAIT_BURROWED, WIDOW_ABILITY_TRAIT)
-	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, WIDOW_ABILITY_TRAIT)
+	ADD_TRAIT(owner, TRAIT_IMMOBILE, ability_name)
+	ADD_TRAIT(owner, TRAIT_BURROWED, ability_name)
+	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, ability_name)
 	// We register for movement so that we unburrow if bombed
 	var/mob/living/carbon/xenomorph/X = owner
 	X.soft_armor = X.soft_armor.modifyRating(fire = -100)
@@ -339,7 +348,7 @@
 			continue
 		remaining_list -= remaining_spiderling
 		owner.buckle_mob(remaining_spiderling, TRUE, TRUE, 90, 1,0)
-		ADD_TRAIT(remaining_spiderling, TRAIT_IMMOBILE, WIDOW_ABILITY_TRAIT)
+		ADD_TRAIT(remaining_spiderling, TRAIT_IMMOBILE, WIDOW_RIDING_TRAIT)
 	addtimer(CALLBACK(src, PROC_REF(grab_spiderlings), remaining_list, number_of_attempts_left - 1), 1)
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -293,7 +293,7 @@
 	owner.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	owner.density = FALSE
 	owner.allow_pass_flags |= PASSABLE
-	// Here we prevent the xeno from moving or attacking or using abilities untill they unburrow by clicking the ability
+	// Here we prevent the xeno from moving or attacking or using abilities until they unburrow by clicking the ability
 	ADD_TRAIT(owner, TRAIT_IMMOBILE, ability_name)
 	ADD_TRAIT(owner, TRAIT_BURROWED, ability_name)
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, ability_name)
@@ -336,6 +336,10 @@
 		X.balloon_alert(X, "No spiderlings")
 		return fail_activate()
 	var/list/mob/living/carbon/xenomorph/spiderling/remaining_spiderlings = create_spiderling_action.spiderlings.Copy()
+	// First make the spiderlings stop what they are doing and return to the widow
+	for(var/mob/spider in remaining_spiderlings)
+		var/datum/component/ai_controller/AI = spider.GetComponent(/datum/component/ai_controller)
+		AI?.ai_behavior.change_action(ESCORTING_ATOM, AI.ai_behavior.escorted_atom)
 	grab_spiderlings(remaining_spiderlings, attach_attempts)
 	succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/widow.dm
@@ -28,3 +28,19 @@
 	M.layer = initial(M.layer)
 	M.pixel_x = rand(-8, 8)
 	M.pixel_y = rand(-8, 8)
+
+/mob/living/carbon/xenomorph/widow/transfer_to_hive(hivenumber)
+	. = ..()
+	var/mob/living/carbon/xenomorph/widow/X = src
+	var/datum/action/xeno_action/create_spiderling/create_spiderling_action = X.actions_by_path[/datum/action/xeno_action/create_spiderling]
+	for(var/mob/living/carbon/xenomorph/spider in create_spiderling_action.spiderlings)
+		spider.transfer_to_hive(hivenumber)
+
+/mob/living/carbon/xenomorph/widow/on_eord(turf/destination)
+	..()
+	var/mob/living/carbon/xenomorph/widow/X = src
+	var/datum/action/xeno_action/create_spiderling/create_spiderling_action = X.actions_by_path[/datum/action/xeno_action/create_spiderling]
+	for(var/mob/living/carbon/xenomorph/spider in create_spiderling_action.spiderlings)
+		spider.revive(TRUE)
+		INVOKE_ASYNC(spider, TYPE_PROC_REF(/atom/movable, forceMove), destination)
+

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -75,6 +75,9 @@
 
 	if(src == X)
 		return TRUE
+	
+	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_LIVING, src, damage_amount, X.xeno_caste.melee_damage * X.xeno_melee_damage_modifier)
+
 	if(isxenolarva(X)) //Larvas can't eat people
 		X.visible_message(span_danger("[X] nudges its head against \the [src]."), \
 		span_danger("We nudge our head against \the [src]."))

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -564,3 +564,7 @@
 		return
 	set_light_range_power_color(range, power, color)
 	set_light_on(TRUE)
+
+/// Side effects of being sent to the end of round deathmatch zone
+/mob/living/carbon/xenomorph/proc/on_eord(turf/destination)
+	revive(TRUE)


### PR DESCRIPTION

## About The Pull Request
A quite a lot of things irked me about the widow, so I decided to do a few fixes to smoothen over the experience and I think it I did quite well.
All the changes are documented in the changelog.

## Why It's Good For The Game
The widow had good potential but it's kinks were never smoothened out, this should deal with most of them.

## Changelog

:cl:
add: Xenos will be fully healed when going to the EORD, plus the widow's spiderlings will be brought with as well.
fix: The widow's spiderlings now attack xenos of a hostile hive, and appropiately change hive types when created, and if the widow's hive is changed
add: Widows spiderlings should no longer leave you stuck as much as widow if they wake up while attached to you, instead actions that risk it, burrowing, resting, now de-attach them from you.
add: Widow's spiderlings will now jump with the widow, hopping spiders ahoy!
qol: Widow's spiderlings will now de-attach from the widow upon attacking objects just like they do when attacking living things.
tweak: The widow's spiderlings now attack and roar at random delays, as doing it all at the same time could be somewhat loud and too robotic.
/:cl:

